### PR TITLE
[CIS Feature] Fix total count when nodes are were disconnected

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -94,3 +94,6 @@ COMPARE_REPORT = 'compare_report.json'
 COMPARE_REPORT_HTML = 'compare_report.html'
 
 REPORT_RESOURCES_PATH = 'resources'
+
+TEST_CASES_JSON_NAME = 'test_cases.json'
+LOST_TESTS_JSON_NAME = 'lost_tests.json'

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -30,6 +30,19 @@ def main(lost_tests_results, tests_dir, output_dir, is_regression):
 	if len(lost_tests_results) == 0:
 		return 0
 
+	# check that session_reports in stashed results is completed and nothing was lost
+	results_directories = next(os.walk(os.path.abspath(output_dir)))[1]
+	for results_directory in results_directories:
+		for path, dirs, files in os.walk(os.path.abspath(os.path.join(output_dir, results_directory))):
+			session_report_exist = False
+			for file in files:
+				if file.endswith(SESSION_REPORT):
+					session_report_exist = True
+					break
+			if not session_report_exist:
+				lost_tests_results.append(results_directory)
+
+
 	if is_regression == 'true':
 		with open(os.path.join(tests_dir, "jobs", "regression.json"), "r") as file:
 			test_packages = json.load(file)
@@ -57,6 +70,7 @@ def main(lost_tests_results, tests_dir, output_dir, is_regression):
 			if joined_gpu_os_names not in lost_tests_data:
 				lost_tests_data[joined_gpu_os_names] = {}
 			lost_tests_data[joined_gpu_os_names][test_package_name] = lost_tests_count
+
 	os.makedirs(output_dir, exist_ok=True)
 	with open(os.path.join(output_dir, LOST_TESTS_JSON_NAME), "w") as file:
 		json.dump(lost_tests_data, file, indent=4, sort_keys=True)

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -1,0 +1,61 @@
+import ast
+import os
+import json
+from core.config import *
+
+
+# match gpu label in Jenkins and part of gpu name which session_report.json contains
+GPU_NAMES_CONVERTATIONS = {
+	"AMD_RXVEGA": "RX Vega",
+	"AMD_RX5700XT": "RX 5700 XT",
+	"AMD_RadeonVII": "Radeon VII",
+	"NVIDIA_GF1080TI": "GTX 1080 Ti",
+	"AMD_WX7100": "WX 7100",
+	"AMD_WX9100": "WX 9100",
+	"NVIDIA_GTX980": "GTX 980",
+	"NVIDIA_RTX2080TI": "RTX 2080 Ti"
+}
+
+# match OS label in Jenkins and part of OS name which session_report.json contains
+OS_NAMES_CONVERTATIONS = {
+	"Windows": "Windows",
+	"Ubuntu": "Ubuntu",
+	"OSX": "Darwin"
+}
+
+def main(lost_tests_results, tests_dir, output_dir, regression = ''):
+	lost_tests_data = {}
+	lost_tests_results = ast.literal_eval(lost_tests_results)
+
+	if len(lost_tests_results) == 0:
+		return 0
+
+	if regression:
+		with open(regression, "r") as file:
+			test_packages = json.load(file)
+		for test_package_name in test_packages:
+			lost_tests_count = len(test_packages[test_package_name].split(','))
+			for lost_test_result in lost_tests_results:
+				gpu_name = lost_test_result.split('-')[0]
+				os_name = lost_test_result.split('-')[1]
+				# join converted gpu name and os name
+				joined_gpu_os_names = GPU_NAMES_CONVERTATIONS[gpu_name] + "-" + OS_NAMES_CONVERTATIONS[os_name]
+				if joined_gpu_os_names not in lost_tests_data:
+					lost_tests_data[joined_gpu_os_names] = {}
+				lost_tests_data[joined_gpu_os_names][test_package_name] = lost_tests_count
+	else:
+		for lost_test_result in lost_tests_results:
+			gpu_name = lost_test_result.split('-')[0]
+			os_name = lost_test_result.split('-')[1]
+			test_package_name = lost_test_result.split('-')[2]
+			with open(os.path.join(tests_dir, "jobs", "Tests", test_package_name, TEST_CASES_JSON_NAME), "r") as file:
+				data = json.load(file)
+			# number of lost tests = number of tests in test package
+			lost_tests_count = len(data)
+			# join converted gpu name and os name
+			joined_gpu_os_names = GPU_NAMES_CONVERTATIONS[gpu_name] + "-" + OS_NAMES_CONVERTATIONS[os_name]
+			if joined_gpu_os_names not in lost_tests_data:
+				lost_tests_data[joined_gpu_os_names] = {}
+			lost_tests_data[joined_gpu_os_names][test_package_name] = lost_tests_count
+	with open(os.path.join(output_dir, LOST_TESTS_JSON_NAME), "w") as file:
+		json.dump(lost_tests_data, file, indent=4, sort_keys=True)

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -23,15 +23,15 @@ OS_NAMES_CONVERTATIONS = {
 	"OSX": "Darwin"
 }
 
-def main(lost_tests_results, tests_dir, output_dir, regression = ''):
+def main(lost_tests_results, tests_dir, output_dir, is_regression):
 	lost_tests_data = {}
 	lost_tests_results = ast.literal_eval(lost_tests_results)
 
 	if len(lost_tests_results) == 0:
 		return 0
 
-	if regression:
-		with open(regression, "r") as file:
+	if is_regression == 'true':
+		with open(os.path.join(tests_dir, "jobs", "regression.json"), "r") as file:
 			test_packages = json.load(file)
 		for test_package_name in test_packages:
 			lost_tests_count = len(test_packages[test_package_name].split(','))

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -57,5 +57,6 @@ def main(lost_tests_results, tests_dir, output_dir, regression = ''):
 			if joined_gpu_os_names not in lost_tests_data:
 				lost_tests_data[joined_gpu_os_names] = {}
 			lost_tests_data[joined_gpu_os_names][test_package_name] = lost_tests_count
+	os.makedirs(output_dir, exist_ok=True)
 	with open(os.path.join(output_dir, LOST_TESTS_JSON_NAME), "w") as file:
 		json.dump(lost_tests_data, file, indent=4, sort_keys=True)

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -179,6 +179,26 @@ def build_session_report(report, session_dir):
     return report
 
 
+def generate_empty_render_result(summary_report, lost_test_package, gpu_os_case, lost_tests_count):
+    summary_report[gpu_os_case]['results'][lost_test_package] = {}
+    # add empty conf
+    summary_report[gpu_os_case]['results'][lost_test_package][""] = {}
+    # specify data
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['duration'] = ""
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['error'] = lost_tests_count
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['failed'] = 0
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['machine_info'] = ""
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['passed'] = 0
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['render_duration'] = ""
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['render_results'] = []
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['result_path'] = ""
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['skipped'] = 0
+    summary_report[gpu_os_case]['results'][lost_test_package][""]['total'] = lost_tests_count
+
+    summary_report[gpu_os_case]['summary']['error'] += lost_tests_count
+    summary_report[gpu_os_case]['summary']['total'] += lost_tests_count
+
+
 def build_summary_report(work_dir):
     summary_report = {}
     common_info = {}
@@ -235,6 +255,35 @@ def build_summary_report(work_dir):
 
     for key in common_info:
         common_info[key] = ' '.join(common_info[key])
+
+    if os.path.exists(os.path.join(work_dir, LOST_TESTS_JSON_NAME)): 
+        with open(os.path.join(work_dir, LOST_TESTS_JSON_NAME), "r") as file:
+            lost_tests_count = json.load(file)
+        for lost_test_result in lost_tests_count:
+            test_case_found = False
+            gpu_name = lost_test_result.split('-')[0]
+            os_name = lost_test_result.split('-')[1]
+            for gpu_os_case in summary_report:
+                if gpu_name in gpu_os_case and os_name in gpu_os_case:
+                    for lost_test_package in lost_tests_count[lost_test_result]:
+                        generate_empty_render_result(summary_report, lost_test_package, gpu_os_case, lost_tests_count[lost_test_result][lost_test_package])
+                    test_case_found = True
+                    break
+            # if all data for GPU + OS was lost (it can be regression.json execution)
+            if not test_case_found:
+                gpu_os_case = lost_test_result.replace('-', ' ')
+                summary_report[gpu_os_case] = {}
+                summary_report[gpu_os_case]['results'] = {}
+                summary_report[gpu_os_case]['summary'] = {}
+                summary_report[gpu_os_case]['summary']['duration'] = ""
+                summary_report[gpu_os_case]['summary']['error'] = 0
+                summary_report[gpu_os_case]['summary']['failed'] = 0
+                summary_report[gpu_os_case]['summary']['passed'] = 0
+                summary_report[gpu_os_case]['summary']['render_duration'] = ""
+                summary_report[gpu_os_case]['summary']['skipped'] = 0
+                summary_report[gpu_os_case]['summary']['total'] = 0
+                for lost_test_package in lost_tests_count[lost_test_result]:
+                    generate_empty_render_result(summary_report, lost_test_package, gpu_os_case, lost_tests_count[lost_test_result][lost_test_package])
 
     return summary_report, common_info
 

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -261,10 +261,10 @@ def build_summary_report(work_dir):
             lost_tests_count = json.load(file)
         for lost_test_result in lost_tests_count:
             test_case_found = False
-            gpu_name = lost_test_result.split('-')[0]
-            os_name = lost_test_result.split('-')[1]
+            gpu_name = lost_test_result.split('-')[0].lower()
+            os_name = lost_test_result.split('-')[1].lower()
             for gpu_os_case in summary_report:
-                if gpu_name in gpu_os_case and os_name in gpu_os_case:
+                if gpu_name in gpu_os_case.lower() and os_name in gpu_os_case.lower():
                     for lost_test_package in lost_tests_count[lost_test_result]:
                         generate_empty_render_result(summary_report, lost_test_package, gpu_os_case, lost_tests_count[lost_test_result][lost_test_package])
                     test_case_found = True

--- a/core/status_exporter.py
+++ b/core/status_exporter.py
@@ -39,7 +39,8 @@ def main(work_dir=''):
     # get summary results
     for execution in summary_report:
         for key in total:
-            total[key] += summary_report[execution]['summary'][key]
+            if summary_report[execution]['summary'][key]:
+                total[key] += summary_report[execution]['summary'][key]
 
     with open(os.path.join(args.work_dir, 'summary_status.json'), 'w') as file:
         json.dump(total, file, indent=' ')

--- a/core/templates/summary_template.html
+++ b/core/templates/summary_template.html
@@ -57,13 +57,23 @@
                 {% endif -%}
                 >{{ report[i].summary.skipped }}</td>
 
+                {% if report[i].summary.duration and report[i].summary.render_duration %}
                 <td>{{ report[i].summary.duration }}</td>
                 <td>{{ report[i].summary.duration - report[i].summary.render_duration }}</td>
+                {% else %}
+                <td>Unknown</td>
+                <td>Unknown</td>
+                {% endif %}
+
+                {% if report[i].summary.render_duration %}
                 <td
                 {%- if report[i].summary.render_duration == -0.0 %}
                 class="badResult"
                 {% endif -%}
                 >{{ report[i].summary.render_duration }}</td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
             </tr>
     {% endfor %}
         </tbody>
@@ -118,6 +128,7 @@
             {% for test_conf, value in report[i].results[test_package] | dictsort %}
 <!--                <td>{{ test_conf }}</td>-->
 
+                {% if report[i].results[test_package][test_conf].machine_info %}
                 <td>
                     <button class="commonButton popupButton" type="button" onclick="openModalWindow('machineInfo{{ loop.index }}_{{ resultsloop.index }}_{{ i }}');return false;">{{ report[i].results[test_package][test_conf].machine_info.host }}</button>
                     <div class="popup" id="machineInfo{{ loop.index }}_{{ resultsloop.index }}_{{ i }}">
@@ -143,12 +154,20 @@
                             </table>
                         </div>
                     </div>
-
                 </td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
 
+                {% if report[i].results[test_package][test_conf].result_path %}
                 <td><a href="{{ report[i].results[test_package][test_conf].result_path }}/report.html">Report</a></td>
                 <td><a href="{{ report[i].results[test_package][test_conf].result_path }}/renderTool.log">Render Log</a></td>
                 <td><a href="{{ report[i].results[test_package][test_conf].result_path }}/../launcher.engine.log">Engine log</a></td>
+                {% else %}
+                <td>Report</td>
+                <td>Render Log</td>
+                <td>Engine log</td>
+                {% endif %}
                 <td>{{ report[i].results[test_package][test_conf].total }}</td>
                 <td>{{ report[i].results[test_package][test_conf].passed }}</td>
 
@@ -170,15 +189,27 @@
                 {% endif %}
                 >{{ report[i].results[test_package][test_conf].skipped }}</td>
 
+                {% if report[i].results[test_package][test_conf].duration %}
                 <td>{{ report[i].results[test_package][test_conf].duration }}</td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
 
+                {% if report[i].results[test_package][test_conf].duration and report[i].results[test_package][test_conf].render_duration %}
                 <td>{{ report[i].results[test_package][test_conf].duration - report[i].results[test_package][test_conf].render_duration }}</td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
 
+                {% if report[i].results[test_package][test_conf].render_duration %}
                 <td
                 {% if report[i].results[test_package][test_conf].render_duration == -0.0 %}
                 class="badResult"
                 {% endif %}
                 >{{ report[i].results[test_package][test_conf].render_duration | round(1) }}</td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
             </tr>
             <tr>
             {% endfor %}
@@ -204,13 +235,23 @@
                 class="skippedStatus"
                 {% endif %}
                 >{{ report[i].summary.skipped }}</td>
+                {% if report[i].summary.duration and report[i].summary.render_duration %}
                 <td>{{ report[i].summary.duration }}</td>
                 <td>{{ report[i].summary.duration - report[i].summary.render_duration }}</td>
+                {% else %}
+                <td>Unknown</td>
+                <td>Unknown</td>
+                {% endif %}
+
+                {% if report[i].summary.render_duration %}
                 <td
                 {% if report[i].summary.render_duration == -0.0 %}
                 class="badResult"
                 {% endif %}
                 >{{ report[i].summary.render_duration | round(1) }}</td>
+                {% else %}
+                <td>Unknown</td>
+                {% endif %}
             </tr>
         </tbody>
     </table>

--- a/count_lost_tests.bat
+++ b/count_lost_tests.bat
@@ -1,2 +1,2 @@
 set PATH=c:\python35\;c:\python35\scripts\;%PATH%
-python -c "import core.countLostTests; core.countLostTests.main(""%1"", '%2', '%3', regression='%4')"
+python -c "import core.countLostTests; core.countLostTests.main(""%1"", '%2', '%3', '%4')"

--- a/count_lost_tests.bat
+++ b/count_lost_tests.bat
@@ -1,2 +1,2 @@
 set PATH=c:\python35\;c:\python35\scripts\;%PATH%
-python -c "import core.countLostTests; core.countLostTests.main(^"%1^", '%2', '%3', regression='%4')"
+python -c "import core.countLostTests; core.countLostTests.main(""%1"", '%2', '%3', regression='%4')"

--- a/count_lost_tests.bat
+++ b/count_lost_tests.bat
@@ -1,0 +1,2 @@
+set PATH=c:\python35\;c:\python35\scripts\;%PATH%
+python -c "import core.countLostTests; core.countLostTests.main(^"%1^", '%2', '%3', regression='%4')"

--- a/count_lost_tests.sh
+++ b/count_lost_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 -c "import core.countLostTests; core.countLostTests.main(\"$1\", '$2', '$3', regression='$4')"
+python3 -c "import core.countLostTests; core.countLostTests.main(\"$1\", '$2', '$3', '$4')"

--- a/count_lost_tests.sh
+++ b/count_lost_tests.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 -c "import core.countLostTests; core.countLostTests.main(\"$1\", '$2', '$3', regression='$4')"


### PR DESCRIPTION
* JIRA TICKET:

  * https://adc.luxoft.com/jira/browse/STVCIS-680

* PURPOSE

  * Fix total count of run tests

* EFFECT OF CHANGE

  * Add script which form json with number of lost tests for each 'GPU-OS' pair
  * Modify summary report building and its template for show "Unknown" when data was lost

* TECHNICAL STEPS

  * Open RPR Blender2.8 Plugin Manual job: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/
  * Choose 'origin/inemankov/total_count_issue_dev' in PipelineBranch.
  * Choose 'origin/inemankov/total_count_issue_dev' in TestsBranch.
  * Start render process
  * Kill any Test stage via closing Jenkins agent.jar bat on machine

* NOTES FOR REVIEWERS

  * None

* REPORTS

  * One failed tests package: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/1347/Test_20Report/
  * Failed regression.json: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/1351/Test_20Report/