### PR TITLE
Add total count feature for Core

### DIFF
--- a/common/scripts/ImageComparator/compareByJSON_ec.py
+++ b/common/scripts/ImageComparator/compareByJSON_ec.py
@@ -47,7 +47,7 @@ def check_pixel_difference(work_dir, base_dir, img, baseline_item, tolerance, pi
 
             metrics = None
             try:
-                metrics = CompareMetrics.CompareMetrics(render_img_path, baseline_img_path)
+                metrics = CompareMetrics(render_img_path, baseline_img_path)
             except (FileNotFoundError, OSError) as err:
                 core.config.main_logger.error("Error file open: ".format(str(err)))
                 return img

--- a/core/config.py
+++ b/core/config.py
@@ -124,7 +124,8 @@ REPORT_RPR_LOG = 'renderTool.log'
 TEST_CASES_JSON_NAME = {
         'blender': 'test_cases.json',
         'maya': 'test_cases.json',
-        'max': 'case_list.json'
+        'max': 'case_list.json',
+        'core': 'SceneList.json'
     }
 LOST_TESTS_JSON_NAME = 'lost_tests.json'
 

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -25,7 +25,8 @@ PLATFORM_CONVERTATIONS = {
 			"NVIDIA_GF1080TI": "GeForce GTX 1080 Ti",
 			"AMD_WX7100": "AMD Radeon (TM) Pro WX 7100 Graphics",
 			"AMD_WX9100": "Radeon (TM) Pro WX 9100",
-			"NVIDIA_RTX2080TI": "GeForce RTX 2080 Ti"
+			"NVIDIA_RTX2080TI": "GeForce RTX 2080 Ti",
+			"NVIDIA_RTX2080": "NVIDIA GeForce RTX 2080"
 		}
 	},
 	"Ubuntu18": {

--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -86,7 +86,7 @@ def main(lost_tests_results, tests_dir, output_dir, is_regression):
 			with open(os.path.join(tests_dir, "jobs", "Tests", test_package_name, TEST_CASES_JSON_NAME[tool_name]), "r") as file:
 				data = json.load(file)
 			# number of lost tests = number of tests in test package
-			if tool_name == 'blender' or tool_name == 'maya':
+			if tool_name == 'blender' or tool_name == 'maya' or tool_name == 'core':
 				lost_tests_count = len(data)
 			elif tool_name == 'max':
 				lost_tests_count = len(data['cases'])

--- a/count_lost_tests.bat
+++ b/count_lost_tests.bat
@@ -1,2 +1,2 @@
 set PATH=c:\python35\;c:\python35\scripts\;%PATH%
-python -c "import core.countLostTests; core.countLostTests.main("""""%1""""", '%2', '%3', '%4')"
+python -c "import core.countLostTests; core.countLostTests.main("""""%1""""", '%2', '%3', '%4', """""%5""""")"

--- a/count_lost_tests.sh
+++ b/count_lost_tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 -c "import core.countLostTests; core.countLostTests.main(""$1"", '$2', '$3', '$4')"
+python3 -c "import core.countLostTests; core.countLostTests.main(""$1"", '$2', '$3', '$4', ""$5"")"


### PR DESCRIPTION
* JIRA TICKET:
  * https://adc.luxoft.com/jira/browse/STVCIS-1085
* PURPOSE
  * Add total count feature for Core.
* EFFECT OF CHANGE
  * Refactor countLostTests script. It can count lost tests for non split execution runs (such as core tests).
* TECHNICAL STEPS
  * None
* NOTES FOR REVIEWERS
  * PRs in other repositories:
    * rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/183
    * jobs_test_core: https://github.com/luxteam/jobs_test_core/pull/14
    * cis_tools: https://github.com/luxteam/cis_tools/pull/4
* REPORTS
  * Blender: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/1795/Test_20Report/
  * Maya: https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3125/Test_20Report/
  * Max: https://rpr.cis.luxoft.com/job/RadeonProRenderMaxPluginManual/858/Test_20Report/
  * Core: https://rpr.cis.luxoft.com/job/RadeonProRenderCoreManual/545/Test_20Report/