### PR TITLE
Fix incorrect display of time in reports

### DIFF
--- a/core/templates/summary_template.html
+++ b/core/templates/summary_template.html
@@ -127,10 +127,14 @@
                             </form>
                             <div class="popupContent popupHalfWidth">
                                 <table class="baseTable" data-toggle="table">
-                                    <tr><th>Time</th><th>Machine</th><th>Link to logs</th></tr>
-                                    {% for retry in report[i].results[test_package][''].machine_info.retries %}
-                                        <tr><td>{{retry['time']}}</td><td>{{retry['host']}}</td><td><a href="{{retry['link']}}">Crash logs</a></td></tr>
-                                    {% endfor %}
+                                    <thead>
+                                        <tr><th>Time</th><th>Machine</th><th>Link to logs</th></tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for retry in report[i].results[test_package][''].machine_info.retries %}
+                                            <tr><td>{{retry['time']}}</td><td>{{retry['host']}}</td><td><a href="{{retry['link']}}">Crash logs</a></td></tr>
+                                        {% endfor %}
+                                    </tbody>
                                 </table>
                             </div>
                         </div>

--- a/core/templates/summary_template.html
+++ b/core/templates/summary_template.html
@@ -230,9 +230,7 @@
                 {% endif %}
                 >{{ report[i].results[test_package][test_conf].render_duration | round(1) }}</td>
             </tr>
-            <tr>
             {% endfor %}
-            </tr>
         {% endfor %}
 
             <tr class="summary_tr">


### PR DESCRIPTION
* JIRA TICKET:
  * https://adc.luxoft.com/jira/browse/STVCIS-1188
* PURPOSE
  * Fix layout in retries table for correct displaying of time cells.
* NOTES FOR REVIEWERS
  * This bug can be reproduced if there is table with case with retry info. All tables after this table will have incorrect time displaying.