### PR TITLE
Fix total count in case of zero number of test in session report (regression)

### DIFF
--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -93,7 +93,7 @@ def main(lost_tests_results, tests_dir, output_dir, execution_type, tests_list):
 									session_report["summary"]["total"] += number_of_cases
 							with open(os.path.join(path, file), "w") as report:
 								json.dump(session_report, report, indent=4, sort_keys=True)
-						elif execution_type == 'split_execution':
+						else:
 							with open(os.path.join(path, file), "r") as report:
 								session_report = json.load(report)
 							if 'summary' not in session_report or 'total' not in session_report['summary'] or session_report['summary']['total'] <= 0:


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1404
### Purpose
* Fix total count in case of zero number of test in session report (regression)
### Effect of change
* Check that number of tests in session report is zero in case of execution regression tests. If it is this test group will be added to list of lost test groups
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderMaxPluginManual/1003/