### PR TITLE
Fix report building failed when too many retries

### DIFF
--- a/build_reports.bat
+++ b/build_reports.bat
@@ -1,2 +1,2 @@
 set PATH=c:\python35\;c:\python35\scripts\;%PATH%
-python -c "import core.reportExporter; core.reportExporter.build_summary_reports('%1', major_title='%2', commit_sha='%3', branch_name='%4', commit_message='%5', node_retry_info='%~6')"
+python -c "import core.reportExporter; core.reportExporter.build_summary_reports('%1', major_title='%2', commit_sha='%3', branch_name='%4', commit_message='%5')"

--- a/build_reports.sh
+++ b/build_reports.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 -c "import core.reportExporter; core.reportExporter.build_summary_reports('$1', major_title='$2', commit_sha='$3', branch_name='$4', commit_message='$5', node_retry_info=\"$6\")"
+python3 -c "import core.reportExporter; core.reportExporter.build_summary_reports('$1', major_title='$2', commit_sha='$3', branch_name='$4', commit_message='$5')"

--- a/core/config.py
+++ b/core/config.py
@@ -138,6 +138,7 @@ TEST_CASES_JSON_NAME = {
         'rprviewer': 'test.cases.json'
     }
 LOST_TESTS_JSON_NAME = 'lost_tests.json'
+RETRY_INFO_NAME = 'retry_info.json'
 
 DONT_COMPARE = "Do not compare"
 

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -516,7 +516,7 @@ def build_local_reports(work_dir, summary_report, common_info, jinja_env):
         main_logger.error(str(err))
 
 
-def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_name='undefined', commit_message='undefined', node_retry_info=''):
+def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_name='undefined', commit_message='undefined'):
     rc = 0
 
     if os.path.exists(os.path.join(work_dir, 'report_resources')):
@@ -546,8 +546,8 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
     common_info = {}
     summary_report = None
 
-    if node_retry_info:
-        node_retry_info = json.loads(bytes(node_retry_info, "utf-8").decode("unicode_escape"))
+    with open(os.path.join(work_dir, RETRY_INFO_NAME), "r") as file:
+        node_retry_info = json.load(file)
 
     main_logger.info("Saving summary report...")
 


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1487
### Purpose
* Fix report building failed when too many retries
### Effect of change
* Save retry info in file for prevent error with too long param of bat file
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/261
### Jenkins Builds
* Common build: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2576/
* A lot of retries: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2583/