### PR TITLE
Make the report generation return code more informative

### DIFF
--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -523,6 +523,11 @@ def build_local_reports(work_dir, summary_report, common_info, jinja_env):
         main_logger.error(str(err))
 
 
+# Expected error return codes
+# -1 - Summary report can't be built
+# -2 - Performance report can't be built
+# -3 - Compare report can't be built
+# -4 - Local reports can't be built
 def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_name='undefined', commit_message='undefined', engine=''):
     rc = 0
 
@@ -624,7 +629,7 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
         traceback.print_exc()
         main_logger.error(performance_html) #local variable 'performance_html' referenced before assignment
         save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
-        rc = -1
+        rc = -2
 
     main_logger.info("Saving compare report...")
     try:
@@ -644,14 +649,14 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
         traceback.print_exc()
         main_logger.error(compare_html)
         save_html_report(compare_html, work_dir, "compare_report.html", replace_pathsep=True)
-        rc = -1
+        rc = -3
 
     try:
         build_local_reports(work_dir, summary_report, common_info, env)
     except Exception as err:
         traceback.print_exc()
         main_logger.error(str(err))
-        rc = -1
+        rc = -4
 
     exit(rc)
 

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -596,10 +596,13 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                                      i=execution)
             save_html_report(detailed_summary_html, work_dir, execution + "_detailed.html", replace_pathsep=True)
     except Exception as err:
-        traceback.print_exc()
-        main_logger.error(summary_html) #FIXME: referenced before assignment
-        save_html_report("Error while building summary report: {}".format(str(err)), work_dir, SUMMARY_REPORT_HTML,
-                         replace_pathsep=True)
+        try:
+            traceback.print_exc()
+            main_logger.error(summary_html)
+            save_html_report("Error while building summary report: {}".format(str(err)), work_dir, SUMMARY_REPORT_HTML,
+                             replace_pathsep=True)
+        except Exception as err:
+            traceback.print_exc()
         rc = -1
 
     main_logger.info("Saving performance report...")
@@ -626,9 +629,12 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                        synchronization_time=sync_time(summary_report))
         save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
     except Exception as err:
-        traceback.print_exc()
-        main_logger.error(performance_html) #local variable 'performance_html' referenced before assignment
-        save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
+        try:
+            traceback.print_exc()
+            main_logger.error(performance_html)
+            save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
+        except Exception as err:
+            traceback.print_exc()
         rc = -2
 
     main_logger.info("Saving compare report...")
@@ -646,9 +652,12 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                common_info=common_info)
         save_html_report(compare_html, work_dir, COMPARE_REPORT_HTML, replace_pathsep=True)
     except Exception as err:
-        traceback.print_exc()
-        main_logger.error(compare_html)
-        save_html_report(compare_html, work_dir, "compare_report.html", replace_pathsep=True)
+        try:
+            traceback.print_exc()
+            main_logger.error(compare_html)
+            save_html_report(compare_html, work_dir, "compare_report.html", replace_pathsep=True)
+        except Exception as err:
+            traceback.print_exc()
         rc = -3
 
     try:


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1457
### Purpose
* Make the report generation return code more informative
### Effect of change
* Return different return codes for failed building of each report (summary, performace, compare, local)
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/301/
### Jenkins Builds
* Common build: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/155/
* Fail summary report building: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/151/
* Fail performance report building: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/156/