### PR TITLE
Implement feature for run regression with multiple engines

### DIFF
--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -112,19 +112,18 @@ def main(lost_tests_results, tests_dir, output_dir, split_tests_execution, tests
 	if split_tests_execution == "true":
 		tests_package_data = {}
 		if tests_package != "none":
-			tests_package_name = tests_package.split(":")[0]
-			with open(os.path.join(tests_dir, "jobs", tests_package_name), "r") as file:
+			with open(os.path.join(tests_dir, "jobs", tests_package.split("~")[0]), "r") as file:
 				tests_package_data = json.load(file)
 			if not tests_package_data["split"]:
 				# e.g. regression
 				lost_package_stach = ""
 				for lost_test_result in lost_tests_results:
-					if lost_test_result.endswith(tests_package_name):
+					if lost_test_result.endswith(tests_package):
 						lost_package_stach = lost_test_result
 						break
 				if lost_package_stach:
 					lost_tests_results.remove(lost_package_stach)
-					excluded_groups = tests_package.split(":")[1].split(";")
+					excluded_groups = tests_package.split("~")[1].split(";")
 					for test_package_name in tests_package_data["groups"]:
 						if test_package_name in excluded_groups:
 							continue

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -226,12 +226,12 @@ def generate_empty_render_result(summary_report, lost_test_package, gpu_os_case,
             for groups in retry_info['Tries']:
                 package_or_default_execution = None
                 for group in groups.keys():
-                    parsed_group_name = group.split(':')[0]
+                    parsed_group_name = group.split('~')[0]
                     #all non splitTestsExecution and non regression builds (e.g. any build of core)
                     if 'DefaultExecution' in group:
                         package_or_default_execution = group
                         break
-                    elif parsed_group_name.endswith('.json') and lost_test_package not in group.split(':')[1]:
+                    elif parsed_group_name.endswith('.json') and lost_test_package not in group.split('~')[1]:
                         with open(os.path.abspath(os.path.join('..', 'jobs', parsed_group_name))) as f:
                             if lost_test_package in json.load(f)['groups']:
                                 package_or_default_execution = group
@@ -769,12 +769,12 @@ def add_retry_info(summary_report, retry_info, work_dir):
                             for groups in retry['Tries']:
                                 package_or_default_execution = None
                                 for group in groups.keys():
-                                    parsed_group_name = group.split(':')[0]
+                                    parsed_group_name = group.split('~')[0]
                                     #all non splitTestsExecution and non regression builds (e.g. any build of core)
                                     if 'DefaultExecution' in group:
                                         package_or_default_execution = group
                                         break
-                                    elif parsed_group_name.endswith('.json') and test_package not in group.split(':')[1]:
+                                    elif parsed_group_name.endswith('.json') and test_package not in group.split('~')[1]:
                                         with open(os.path.abspath(os.path.join('..', 'jobs', parsed_group_name))) as f:
                                             if test_package in json.load(f)['groups']:
                                                 package_or_default_execution = group

--- a/executeTests.py
+++ b/executeTests.py
@@ -127,14 +127,14 @@ def main():
     # extend test_filter by values in file_filter
     if args.file_filter and args.file_filter != 'none':
         try:
-            file_name = args.file_filter.split(':')[0]
+            file_name = args.file_filter.split('~')[0]
             with open(os.path.join(args.tests_root, file_name), 'r') as file:
                 file_content = json.load(file)
                 # exclude some tests from non-splitted tests package
                 if not file_content['split']:
                     # save path to tests package
                     args.cmd_variables['TestCases'] = os.path.abspath(os.path.join(args.tests_root, file_name))
-                    excluded_tests = args.file_filter.split(':')[1].split(';')
+                    excluded_tests = args.file_filter.split('~')[1].split(';')
                     args.test_filter.extend([x for x in file_content['groups'].keys() if x not in excluded_tests])
         except Exception as e:
             main_logger.error(str(e))


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1549
### Purpose
* Implement feature for run regression with multiple engines
### Effect of change
* Replace ":" by "~" as a separator of package name and excluded tests (Jenkins can't save stash if in name of stash where is ":")
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/303
### Jenkins Builds
* Tahoe + Northstar: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/178/Test_20Report/
* Check total count: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/175/Test_20Report/