### PR TITLE
Fix builds with regression + more than one additional group

### DIFF
--- a/core/countLostTests.py
+++ b/core/countLostTests.py
@@ -123,7 +123,7 @@ def main(lost_tests_results, tests_dir, output_dir, split_tests_execution, tests
 						break
 				if lost_package_stach:
 					lost_tests_results.remove(lost_package_stach)
-					excluded_groups = tests_package.split("~")[1].split(";")
+					excluded_groups = tests_package.split("~")[1].split(",")
 					for test_package_name in tests_package_data["groups"]:
 						if test_package_name in excluded_groups:
 							continue

--- a/executeTests.py
+++ b/executeTests.py
@@ -134,7 +134,7 @@ def main():
                 if not file_content['split']:
                     # save path to tests package
                     args.cmd_variables['TestCases'] = os.path.abspath(os.path.join(args.tests_root, file_name))
-                    excluded_tests = args.file_filter.split('~')[1].split(';')
+                    excluded_tests = args.file_filter.split('~')[1].split(',')
                     args.test_filter.extend([x for x in file_content['groups'].keys() if x not in excluded_tests])
         except Exception as e:
             main_logger.error(str(e))


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1635
### Purpose
* Fix builds with regression + more than one additional groups
### Effect of change
* Replace ';' by ',' in names of groups for regression package (';' is depricated symbol in name of stashes)
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/317
### Jenkins Builds
* Blender (regression + AOV & Animation): https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/205/
* Blender (check logs): https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/2801/
* Maya (check logs): https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/3802/