### PR TITLE
Save json files of cases with indentations in progress_monitor

### DIFF
--- a/image_service_client.py
+++ b/image_service_client.py
@@ -2,7 +2,7 @@ import json
 from requests.auth import HTTPBasicAuth
 from requests import get, post, put
 from requests.exceptions import RequestException
-from core.config import main_logger, MAX_UMS_SEND_RETRIES
+from core.config import main_logger, MAX_UMS_SEND_RETRIES, UMS_SEND_RETRY_INTERVAL
 import traceback
 import time
 

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -67,7 +67,7 @@ def send_finished_cases(session_dir, suite_name):
             case_file_data['image_service_id'] = image_id
             
         with open(os.path.join(session_dir, suite_name, test_case + '_RPR.json'), 'w') as case_file:
-            json.dump([case_file_data], case_file)
+            json.dump([case_file_data], case_file, indent=4, sort_keys=True)
 
     transferred_test_cases += list(new_test_cases.keys())
     diff = len(test_cases) - len(transferred_test_cases)


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1736
### Purpose
* Save json files of cases with indentations in progress_monitor (it reproduces issues like that https://rpr.cis.luxoft.com/view/RPR-Baikal/job/RadeonProViewer-WeeklyFull/103/Test_20Report/ due to current implementation of makeReport scripts which parse json files by lines)
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProViewerManual/914/
* https://rpr.cis.luxoft.com/job/RadeonProViewerManual/915/
* https://rpr.cis.luxoft.com/job/RadeonProRenderMaxPluginManual/1062/
* https://rpr.cis.luxoft.com/job/RadeonProViewerManual/916/