### PR TITLE
Mark test case correctly in case of missing baseline json

### DIFF
--- a/common/scripts/compareByJSON.py
+++ b/common/scripts/compareByJSON.py
@@ -56,7 +56,8 @@ def get_pixel_difference(work_dir, base_dir, img, tolerance, pix_diff_max):
             img.update({'baseline_color_path': os.path.relpath(
                 os.path.join(base_dir, 'baseline.png'), work_dir)})
             img['message'].append('Baseline not found')
-            img.update({'test_status': core.config.TEST_DIFF_STATUS})
+            if img['test_status'] != core.config.TEST_CRASH_STATUS:
+                img.update({'test_status': core.config.TEST_DIFF_STATUS})
             core.config.main_logger.error(
                 "Baseline json not found by path: {}".format(path_to_baseline_json))
             return img


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1710
### Purpose
* Mark test case as failed only if isn't errored (in case of missing baseline json)
### Jenkins Builds
* https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/59/