### PR TITLE
Add detailed error logging

### DIFF
--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -299,7 +299,9 @@ def build_summary_report(work_dir, node_retry_info, collect_tracked_metrics):
                     temp_report = json.loads(report_file.read())
                     try:
                         basename = temp_report['machine_info']['render_device'] + ' ' + temp_report['machine_info']['os']
-                    except KeyError:
+                    except KeyError as err:
+                        traceback.print_exc()
+                        main_logger.error(repr(err))
                         continue
 
                     # update relative paths
@@ -726,13 +728,15 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                                      i=execution)
             save_html_report(detailed_summary_html, work_dir, execution + "_detailed.html", replace_pathsep=True)
     except Exception as err:
+        traceback.print_exc()
+        main_logger.error(repr(err))
         try:
-            traceback.print_exc()
             main_logger.error(summary_html)
             save_html_report("Error while building summary report: {}".format(str(err)), work_dir, SUMMARY_REPORT_HTML,
                              replace_pathsep=True)
-        except Exception as err:
+        except Exception as e:
             traceback.print_exc()
+            main_logger.error(repr(e))
         rc = -1
 
     main_logger.info("Saving performance report...")
@@ -759,12 +763,14 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                        synchronization_time=sync_time(summary_report))
         save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
     except Exception as err:
+        traceback.print_exc()
+        main_logger.error(repr(err))
         try:
-            traceback.print_exc()
             main_logger.error(performance_html)
             save_html_report(performance_html, work_dir, PERFORMANCE_REPORT_HTML, replace_pathsep=True)
-        except Exception as err:
+        except Exception as e:
             traceback.print_exc()
+            main_logger.error(repr(e))
         # TODO: make building of performance tab more stable
         # rc = -2
 
@@ -783,12 +789,14 @@ def build_summary_reports(work_dir, major_title, commit_sha='undefined', branch_
                                                common_info=common_info)
         save_html_report(compare_html, work_dir, COMPARE_REPORT_HTML, replace_pathsep=True)
     except Exception as err:
+        traceback.print_exc()
+        main_logger.error(repr(err))
         try:
-            traceback.print_exc()
             main_logger.error(compare_html)
             save_html_report(compare_html, work_dir, "compare_report.html", replace_pathsep=True)
-        except Exception as err:
+        except Exception as e:
             traceback.print_exc()
+            main_logger.error(repr(e))
         rc = -3
 
     try:


### PR DESCRIPTION
### Description
Add detailed error logging. In current commit, when session_report.json didn't have 'os' field, or some fiels are have different data type, reportExporter.py returns empty summary_report.json, perfomance_reports.json and comare_report.json **without informing about errors in log** . Now logging are working.
### Jenkins report
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3146/