### PR TITLE
Added common makeReport.py

### DIFF
--- a/common/scripts/makeReport.py
+++ b/common/scripts/makeReport.py
@@ -1,0 +1,27 @@
+import sys
+import json
+import os
+import argparse
+
+sys.path.append(
+    os.path.abspath(
+        os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)
+        )
+    )
+import core.performance_counter as perf_count
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--work_dir', required=True)
+    args = parser.parse_args()
+    wd = args.work_dir
+    perf_count.event_record(wd, 'Make report json', True)
+    reports = [
+        json.load(open(os.path.join(wd, e), 'r'))[0] for e in list(
+            filter(
+                lambda x: x.endswith('RPR.json'), os.listdir(wd)
+            )
+        )
+    ]
+    with open(os.path.join(wd, 'report.json'), 'w') as f: json.dump(reports, f, indent=4)
+    perf_count.event_record(wd, 'Make report json', False)


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1942
### Purpose
* Make a common `makeReport.py` script for all tests repositories.
### Effect of change
* Now repositories with autotests calls unified `makeReport.py` from jobs_launcher.
### Technical steps
- [x] Refactor `makeReport.py` to actual state and codestyle.
- [x] Add created script to `common/scripts/`.
### Jenkins Builds
* Maya: https://rpr.cis.luxoft.com/job/DevRadeonProRenderMayaPluginManual/76/
* Core: https://rpr.cis.luxoft.com/job/DevRadeonProRenderCoreManual/86/
* USD: https://rpr.cis.luxoft.com/job/DevRadeonProRenderUSDPluginManual/97/
* Max: https://rpr.cis.luxoft.com/job/DevRadeonProRenderMaxPluginManual/3/
* Blender: https://rpr.cis.luxoft.com/job/DevRadeonProRenderBlender2.8PluginManual/598/