### PR TITLE
Egurin/fix upload minio dir

### DIFF
--- a/executeTests.py
+++ b/executeTests.py
@@ -305,9 +305,11 @@ def main():
                         path_to_test_case_log = os.path.join(session_dir, suite_name, 'render_tool_logs', case["test_case"] + ".log")
                         if os.path.exists(path_to_test_case_log):
                             if ums_client_prod and mc_prod:
-                                mc_prod.upload_file(path_to_test_case_log, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id, case["test_case"])
+                                mc_prod.upload_file(path_to_test_case_log, "PROD",ums_client_prod.build_id,
+                                    ums_client_prod.suite_id, ums_client_prod.env_label, case["test_case"])
                             if ums_client_dev and mc_dev:
-                                mc_dev.upload_file(path_to_test_case_log, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id, case["test_case"])
+                                mc_dev.upload_file(path_to_test_case_log, "DEV", ums_client_dev.build_id,
+                                    ums_client_dev.suite_id, ums_client_dev.env_label, case["test_case"])
                     except Exception as e1:
                         main_logger.error("Failed to send results for case {}. Error: {}".format(e1, str(e1)))
                         main_logger.error("Traceback: {}".format(traceback.format_exc()))
@@ -319,9 +321,11 @@ def main():
                     path_to_test_suite_render_log = os.path.join(session_dir, suite_name, artefact)
                     if os.path.exists(path_to_test_suite_render_log):
                         if ums_client_prod and mc_prod:
-                            mc_prod.upload_file(path_to_test_suite_render_log, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id)
+                            mc_prod.upload_file(path_to_test_suite_render_log, "PROD",
+                                ums_client_prod.build_id, ums_client_prod.suite_id, ums_client_prod.env_label)
                         if ums_client_dev and mc_dev:
-                            mc_dev.upload_file(path_to_test_suite_render_log, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id)
+                            mc_dev.upload_file(path_to_test_suite_render_log, "DEV",
+                                ums_client_dev.build_id, ums_client_dev.suite_id, ums_client_prod.env_label)
 
                 if ums_client_prod:
                     ums_client_prod.get_suite_id_by_name(suite_name)
@@ -418,10 +422,12 @@ def main():
                 for suite in suites:
                     if ums_client_prod and mc_prod:
                         ums_client_prod.get_suite_id_by_name(suite_name)
-                        mc_prod.upload_file(path_to_test_suite_render_log, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id)
+                        mc_prod.upload_file(path_to_test_suite_render_log, "PROD",
+                            ums_client_prod.build_id, ums_client_prod.suite_id, ums_client_prod.env_label)
                     if ums_client_dev and mc_dev:
                         ums_client_dev.get_suite_id_by_name(suite_name)
-                        mc_dev.upload_file(path_to_test_suite_render_log, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id)
+                        mc_dev.upload_file(path_to_test_suite_render_log, "DEV",
+                            ums_client_dev.build_id, ums_client_dev.suite_id, ums_client_dev.env_label)
 
 
         except Exception as e:

--- a/executeTests.py
+++ b/executeTests.py
@@ -284,6 +284,8 @@ def main():
                                     data = json.load(file)[0]
                                     if 'image_service_id' in data:
                                         rendered_image = str(data['image_service_id'])
+                            else:
+                                main_logger.error("File {} does not exists. Mark case {} image as error.".format(test_case_path, case['test_case']))
 
                         case_info = {}
                         for key in case:
@@ -311,7 +313,8 @@ def main():
                                 mc_dev.upload_file(path_to_test_case_log, "DEV", ums_client_dev.build_id,
                                     ums_client_dev.suite_id, ums_client_dev.env_label, case["test_case"])
                     except Exception as e1:
-                        main_logger.error("Failed to send results for case {}. Error: {}".format(e1, str(e1)))
+                        if 'test_case' in case:
+                            main_logger.error("UMS failed to prepare results for case {}. Error: {}".format(case['test_case'], str(e1)))
                         main_logger.error("Traceback: {}".format(traceback.format_exc()))
                 #TODO: send logs for each test cases
                 
@@ -431,7 +434,7 @@ def main():
 
 
         except Exception as e:
-            main_logger.error("Test case result creation error: {}".format(str(e)))
+            main_logger.error("UMS Failed in preparing test cases results and sending")
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
             shutil.copyfile('launcher.engine.log', os.path.join(session_dir, 'launcher.engine.log'))
     else:

--- a/minio_client.py
+++ b/minio_client.py
@@ -1,4 +1,5 @@
 import os
+import time
 from core.config import main_logger, MAX_UMS_SEND_RETRIES, UMS_SEND_RETRY_INTERVAL
 import subprocess
 import sys

--- a/minio_client.py
+++ b/minio_client.py
@@ -42,7 +42,7 @@ def create_mc_client(job_id):
         )
         return mc
     except Exception as e:
-        main_logger.error("MINIO Client creation error: {}")
+        main_logger.error("MINIO Client creation error")
         main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
 

--- a/minio_client.py
+++ b/minio_client.py
@@ -42,7 +42,7 @@ def create_mc_client(job_id):
         )
         return mc
     except Exception as e:
-        main_logger.error("MINIO Client creation error: {}".format(e))
+        main_logger.error("MINIO Client creation error: {}")
         main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
 
@@ -89,8 +89,9 @@ class UMS_Minio:
                 main_logger.info("Artifact '{}' sent to MINIO".format(artifact_name))
                 file_sent = True
             except Exception as e:
-                main_logger.error(str(e))
-            main_logger.info('File sent to MINIO for UMS {} with result {} (try #{})'.format(ums_name, file_sent, send_try))
+                main_logger.error("MINIO file sending error")
+                main_logger.error("Traceback: {}".format(traceback.format_exc()))
+            main_logger.info('File {} sent to MINIO for UMS {} with result {} (try #{})'.format(file_path, ums_name, file_sent, send_try))
             if file_sent:
                 break
             send_try += 1

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -93,10 +93,10 @@ def send_finished_cases(session_dir, suite_name):
 
     if ums_client_prod:
         ums_client_prod.get_suite_id_by_name(suite_name)
-        minio_client_prod.upload_file(test_cases_path, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id or "", ums_client.env_label)
+        minio_client_prod.upload_file(test_cases_path, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id or "", ums_client_prod.env_label)
     if ums_client_dev:
         ums_client_dev.get_suite_id_by_name(suite_name)
-        minio_client_dev.upload_file(test_cases_path, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id or "", ums_client.env_label)
+        minio_client_dev.upload_file(test_cases_path, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id or "", ums_client_dev.env_label)
 
     for test_case in new_test_cases:
         try:

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -124,7 +124,7 @@ def send_finished_cases(session_dir, suite_name):
             transferred_test_cases.append(test_case)
 
         except Exception as e:
-            main_logger.error("UMS progress monitor failed iteration of test case {} send.")
+            main_logger.error("UMS progress monitor failed iteration of test case {} send.".format(test_case))
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
     diff = len(test_cases) - len(transferred_test_cases)

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -43,11 +43,14 @@ def get_cases_existence_info_by_hashes(session_dir, suite_name, test_cases):
     cases_hashes_info = {}
     cases_hashes = {}
     for case in test_cases:
-        with open(os.path.join(session_dir, suite_name, case + '_RPR.json')) as case_file:
-            case_file_data = json.load(case_file)[0]
-            with open(render_color_full_path(session_dir, suite_name, case_file_data['render_color_path']), 'rb') as img:
-                bytes_data = img.read()
-                cases_hashes[case] = hashlib.md5(bytes_data).hexdigest()
+        try:
+            with open(os.path.join(session_dir, suite_name, case + '_RPR.json')) as case_file:
+                case_file_data = json.load(case_file)[0]
+                with open(render_color_full_path(session_dir, suite_name, case_file_data['render_color_path']), 'rb') as img:
+                    bytes_data = img.read()
+                    cases_hashes[case] = hashlib.md5(bytes_data).hexdigest()
+        except:
+            pass
 
     hash_info_from_is = is_client.get_existence_info_by_hash(
         [case_hash for case, case_hash in cases_hashes.items() if case_hash]

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                 break
         except Exception as e:
             fails_in_succession += 1
-            main_logger.error("UMS progress monitor failed look up for new cases iteration. Sleep for {}".format(args.interval))
+            main_logger.error("UMS progress monitor failed look up for new cases iteration. Sleep for {} seconds".format(args.interval))
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
         if MAX_UMS_SEND_RETRIES == fails_in_succession:
             break

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -13,6 +13,8 @@ import traceback
 res = []
 transferred_test_cases = []
 
+main_logger.info("UMS progress monitor is running")
+
 is_client = None
 ums_client_prod = create_ums_client("PROD")
 ums_client_dev = create_ums_client("DEV")
@@ -28,9 +30,9 @@ try:
         login=os.getenv("IS_LOGIN"),
         password=os.getenv("IS_PASSWORD")
     )
-    main_logger.info("Image Service client created for url: {}".format(is_client.url))
+    main_logger.info("UMS progress monitor Image Service client created for url: {}".format(is_client.url))
 except Exception as e:
-    main_logger.error("Can't create Image Service client for url: {}. Error: {}".format(is_client.url, str(e)))
+    main_logger.error("UMS progress monitor can't create Image Service client for url: {}. Error: {}".format(is_client.url, str(e)))
 
 
 def render_color_full_path(session_dir, suite_name, render_color_path):
@@ -122,7 +124,7 @@ def send_finished_cases(session_dir, suite_name):
             transferred_test_cases.append(test_case)
 
         except Exception as e:
-            main_logger.error("Failed iteration of test case {} send: {}".format(test_case, e))
+            main_logger.error("UMS progress monitor failed iteration of test case {} send.")
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
     diff = len(test_cases) - len(transferred_test_cases)
@@ -148,10 +150,11 @@ if __name__ == '__main__':
             result = send_finished_cases(args.session_dir, args.suite_name)
             fails_in_succession = 0
             if result:
+                main_logger.info("UMS progress monitor send all expected results.")
                 break
         except Exception as e:
             fails_in_succession += 1
-            main_logger.error("Failed iteration of progress monitor: {}".format(e))
+            main_logger.error("UMS progress monitor failed look up for new cases iteration. Sleep for {}".format(args.interval))
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
         if MAX_UMS_SEND_RETRIES == fails_in_succession:
             break

--- a/progress_monitor.py
+++ b/progress_monitor.py
@@ -93,10 +93,10 @@ def send_finished_cases(session_dir, suite_name):
 
     if ums_client_prod:
         ums_client_prod.get_suite_id_by_name(suite_name)
-        minio_client_prod.upload_file(test_cases_path, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id)
+        minio_client_prod.upload_file(test_cases_path, "PROD", ums_client_prod.build_id, ums_client_prod.suite_id, ums_client.env_label)
     if ums_client_dev:
         ums_client_dev.get_suite_id_by_name(suite_name)
-        minio_client_dev.upload_file(test_cases_path, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id)
+        minio_client_dev.upload_file(test_cases_path, "DEV", ums_client_dev.build_id, ums_client_dev.suite_id, ums_client.env_label)
     for test_case in new_test_cases:
         print('Sending artefacts & images for: {}'.format(test_case))
         with open(os.path.join(session_dir, suite_name, test_case + '_RPR.json')) as case_file:

--- a/ums_client.py
+++ b/ums_client.py
@@ -100,14 +100,13 @@ class UMS_Client:
                 ),
                 headers=self.headers
             )
-            main_logger.info("Get suite id by name {}".format(suite_name))
+            main_logger.info("UMS get suite id by name {}".format(suite_name))
             suites = [el['suite'] for el in json.loads(response.content.decode("utf-8"))['suites'] if el['suite']['name'] == suite_name]
             self.suite_id = suites[0]['_id']
 
         except Exception as e:
             self.suite_id = None
-            main_logger.error("Suite id getting error")
-            main_logger.error(str(e))
+            main_logger.error("UMS suite id getting error")
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
 
@@ -128,7 +127,7 @@ class UMS_Client:
                     job_id=self.job_id
                 )
             )
-            main_logger.info('Test suite result sent with code {}'.format(response.status_code))
+            main_logger.info('Test suite result sent to UMS with code {}'.format(response.status_code))
 
             if response.status_code == 401:
                 self.get_token()
@@ -136,7 +135,7 @@ class UMS_Client:
             return response
 
         except Exception as e:
-            main_logger.error("Test suite result send error: {}".format(str(e)))
+            main_logger.error("Test suite result send to UMS error")
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
 
@@ -151,12 +150,12 @@ class UMS_Client:
                     product_id=self.job_id
                 )
             )
-            main_logger.info('Test suite performance sent with code {}'.format(response.status_code))
+            main_logger.info('Test suite performance sent with code {}. test_suite_result_id = {}'.format(response.status_code, test_suite_result_id))
 
             return response
 
         except Exception as e:
-            main_logger.error("Test suite performance send error: {}".format(str(e)))
+            main_logger.error("Test suite performance for UMS send error. test_suite_result_id = {}".format(test_suite_result_id))
             main_logger.error("Traceback: {}".format(traceback.format_exc()))
 
 
@@ -176,9 +175,9 @@ class UMS_Client:
                     job_id=self.job_id
                 )
             )
-            main_logger.info("Environment defined with code {}".format(response.status_code))
+            main_logger.info("Environment defined for UMS with code {}".format(response.status_code))
             return response
 
         except Exception as e:
-            main_logger.error("Environment definition error: {}".format(str(e)))
+            main_logger.error("Environment definition for UMS error")
             main_logger.error("Traceback: {}".format(traceback.format_exc()))


### PR DESCRIPTION
### Purpose
* Fix same logs for all environments in minio
* Improve logging information
* Add retry to each test_case info append and artifacts sending to avoid situation with failed all cases list like here https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4203/Test_20Report/Tahoe/AMD_RXVEGA-Windows-Smoke/Results/Maya/launcher.engine.log
* Fix minio retry

### Effect of change
* Artifacts send to dirs with environment label
* Minio send sleep works
* Log messages have more info
* Avoid situation with failed all cases list

### Technical steps
* Import time to minio_client
* Wrap append test case info to try catch
* Add info about ums to log messages
* Remove str(exception) from log message where next log is traceback (it includes exception info)
* Add env_label to each minio file uploading folder name

### Jenkins Builds
* https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3264/
* https://ums.cistest.luxoft.com/products/5f3b1557929d5171e9d25757/5fe591d28b568a2fa8777fe7/summary
* https://rpr.cis.luxoft.com/job/RadeonProRenderMayaPluginManual/4247/Test_20Report/Tahoe/AMD_RXVEGA-Windows-Smoke/Results/Maya/launcher.engine.log (here also you can see error in one case like in 4203 and results are correct)
* https://ums.cistest.luxoft.com/products/5f3b1557929d5171e9d2575a/5fe591478b568a2fa8777efd/5f3bc463471e5c556272974c/5fe591478b568a2fa8777efe
* minio example for 4247 maya https://minio.cistest.luxoft.com/minio/5f3b1557929d5171e9d2575a/5fe591478b568a2fa8777efd/5f3bc463471e5c556272974c/Windows-AMD_RXVEGA/