### PR TITLE
Add column with build name

### DIFF
--- a/core/templates/base_table_block.html
+++ b/core/templates/base_table_block.html
@@ -14,6 +14,7 @@
             <th>Branch name</th>
             <th>Commit SHA</th>
             <th>Commit message</th>
+            <th>Build name</th>
             {% if common_info.engine %}
                 <th>Engine</th>
             {% endif %}
@@ -36,6 +37,7 @@
             <td>{{ common_info.branch_name }}</td>
             <td>{{ common_info.commit_sha }}</td>
             <td>{{ common_info.commit_message }}</td>
+            <td>{{ env_override("BUILD_NAME") }}</td>
             {% if common_info.engine %}
                 <td>{{ common_info.engine }}</td>
             {% endif %}

--- a/core/templates/base_table_block.html
+++ b/core/templates/base_table_block.html
@@ -1,6 +1,7 @@
 {% if pageID %}
     <table class="baseTable">
         <tr>
+            <th>Build name</th>
             <th>Testing start</th>
             {% if report_type == 'ec' %}
                 {# Core #}
@@ -14,12 +15,12 @@
             <th>Branch name</th>
             <th>Commit SHA</th>
             <th>Commit message</th>
-            <th>Build name</th>
             {% if common_info.engine %}
                 <th>Engine</th>
             {% endif %}
         </tr>
         <tr>
+            <td>{{ "" | env_override("BUILD_NAME") }}</td>
             <td>{{ common_info.reporting_date | env_override("JOB_STARTED_TIME") }}</td>
             {% if report_type == 'ec' %}
                 {# Core #}
@@ -37,7 +38,6 @@
             <td>{{ common_info.branch_name }}</td>
             <td>{{ common_info.commit_sha }}</td>
             <td>{{ common_info.commit_message }}</td>
-            <td>{{ "" | env_override("BUILD_NAME") }}</td>
             {% if common_info.engine %}
                 <td>{{ common_info.engine }}</td>
             {% endif %}

--- a/core/templates/base_table_block.html
+++ b/core/templates/base_table_block.html
@@ -37,7 +37,7 @@
             <td>{{ common_info.branch_name }}</td>
             <td>{{ common_info.commit_sha }}</td>
             <td>{{ common_info.commit_message }}</td>
-            <td>{{ env_override("BUILD_NAME") }}</td>
+            <td>{{ "" | env_override("BUILD_NAME") }}</td>
             {% if common_info.engine %}
                 <td>{{ common_info.engine }}</td>
             {% endif %}


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-2034
### Purpose
* Set build name (without priority) as env variable for use it in jobs_launcher during report building
### :octocat: Related PR'S
* rpr_pipelines: https://github.com/luxteam/rpr_pipelines/pull/414
### Jenkins Builds
* Blender: https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3350/Test_20Report/