### PR TITLE
Empty "Testing start" cell in local reports

### DIFF
--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -557,7 +557,7 @@ def build_local_reports(work_dir, summary_report, common_info, jinja_env, groupp
                     if os.path.exists(os.path.join(work_dir, report_dir, TEST_REPORT_NAME_COMPARED)):
                         with open(os.path.join(work_dir, report_dir, TEST_REPORT_NAME_COMPARED), 'r') as file:
                             render_report = json.loads(file.read())
-                            keys_for_upd = ['tool', 'render_device', 'testing_start', 'test_group']
+                            keys_for_upd = ['tool', 'render_device', 'date_time', 'test_group']
                             for key_upd in keys_for_upd:
                                 if key_upd in render_report[0].keys():
                                     common_info.update({key_upd: render_report[0][key_upd]})

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -326,8 +326,8 @@ def build_summary_report(work_dir, node_retry_info, collect_tracked_metrics):
                                     for key in common_info:
                                         if not temp_report['machine_info'][key] in common_info[key]:
                                             if key == 'reporting_date':
-                                                if common_info[key] > temp_report["results"]["Transform"][""]["render_results"][0]["date_time"]:
-                                                    common_info[key] = temp_report["results"]["Transform"][""]["render_results"][0]["date_time"] 
+                                                if common_info.get(key, [''])[0] > temp_report['machine_info'][key]:
+                                                    common_info[key] = [temp_report['machine_info'][key]]
                                             elif key == 'render_version' and temp_report['machine_info'][key]:
                                                 common_info[key].append(temp_report['machine_info'][key])
                                                 if len(common_info[key]) > 1:

--- a/core/reportExporter.py
+++ b/core/reportExporter.py
@@ -326,8 +326,8 @@ def build_summary_report(work_dir, node_retry_info, collect_tracked_metrics):
                                     for key in common_info:
                                         if not temp_report['machine_info'][key] in common_info[key]:
                                             if key == 'reporting_date':
-                                                if common_info.get(key, [''])[0] > temp_report['machine_info'][key]:
-                                                    common_info[key] = [temp_report['machine_info'][key]]
+                                                if common_info[key] > temp_report["results"]["Transform"][""]["render_results"][0]["date_time"]:
+                                                    common_info[key] = temp_report["results"]["Transform"][""]["render_results"][0]["date_time"] 
                                             elif key == 'render_version' and temp_report['machine_info'][key]:
                                                 common_info[key].append(temp_report['machine_info'][key])
                                                 if len(common_info[key]) > 1:

--- a/core/templates/base_table_block.html
+++ b/core/templates/base_table_block.html
@@ -79,7 +79,7 @@
                 <td>{{ common_info.render_version }}</td>
                 <td>{{ common_info.core_version }}</td>
             {% endif %}
-            <td>{{ common_info.testing_start }}</td>
+            <td>{{ common_info.date_time }}</td>
             <td>{{ common_info.branch_name }}</td>
             <td>{{ common_info.commit_sha }}</td>
             <td>{{ common_info.commit_message }}</td>


### PR DESCRIPTION
### Jira Ticket
* https://adc.luxoft.com/jira/browse/STVCIS-1952
### Purpose
* Change "testing_time" to "data_time" in templates
### Effect of change
* In the empty cell "Testing start" appears the start time of the test group in local reports
### Jenkins build
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3521/Test_20Report/- master build without content in "Testing start" cell
https://rpr.cis.luxoft.com/job/RadeonProRenderBlender2.8PluginManual/3517/Test_20Report/ - with content and that branch